### PR TITLE
Accept encoded url character

### DIFF
--- a/activelink/templatetags/activelink.py
+++ b/activelink/templatetags/activelink.py
@@ -1,3 +1,4 @@
+import urllib
 from django.template import Library, Node, NodeList, VariableDoesNotExist
 from django.core.urlresolvers import NoReverseMatch
 from django.templatetags.future import url
@@ -39,7 +40,7 @@ class ActiveLinkNodeBase(Node):
             )
             return self.nodelist_false.render(context)
 
-        equal = self.is_active(request, var)
+        equal = self.is_active(urllib.unquote(request.path), urllib.unquote(var))
 
         if equal:
             return self.nodelist_true.render(context)
@@ -49,20 +50,20 @@ class ActiveLinkNodeBase(Node):
 
 class ActiveLinkEqualNode(ActiveLinkNodeBase):
 
-    def is_active(self, request, path_to_check):
-        return path_to_check == request.path
+    def is_active(self, request_path, path_to_check):
+        return path_to_check == request_path
 
 
 class ActiveLinkStartsWithNode(ActiveLinkNodeBase):
 
-    def is_active(self, request, path_to_check):
-        return request.path.startswith(path_to_check)
+    def is_active(self, request_path, path_to_check):
+        return request_path.startswith(path_to_check)
 
 
 class ActiveLinkContainsNode(ActiveLinkNodeBase):
 
-    def is_active(self, request, path_to_check):
-        return path_to_check in request.path
+    def is_active(self, request_path, path_to_check):
+        return path_to_check in request_path
 
 
 def parse(parser, token, end_tag):

--- a/activelink/tests/tests.py
+++ b/activelink/tests/tests.py
@@ -133,3 +133,14 @@ def test_with_querystring():
     data = {'request': rf.get('/test-url/?foo=bar')}
     rendered = render(template, data)
     assert rendered == 'on'
+
+def test_with_encodedchar():
+    template = """{% ifactive "test_with_arg" "encoded@arg" %}on{% else %}off{% endifactive %}"""
+
+    data = {'request': rf.get('/test-url-with-arg/encoded%40arg/')}
+    rendered = render(template, data)
+    assert rendered == 'on'
+
+    data = {'request': rf.get('/test-url-with-arg/encoded@arg/')}
+    rendered = render(template, data)
+    assert rendered == 'on'

--- a/activelink/tests/urls.py
+++ b/activelink/tests/urls.py
@@ -4,6 +4,6 @@ from django.http import HttpResponse
 
 urlpatterns = patterns('',
     url(r'^test-url/$', lambda r: HttpResponse('ok'), name='test'),
-    url(r'^test-url-with-arg/([-\w]+)/$', lambda r, arg: HttpResponse('ok'), name='test_with_arg'),
-    url(r'^test-url-with-kwarg/(?P<arg>[-\w]+)/$', lambda r, arg: HttpResponse('ok'), name='test_with_kwarg'),
+    url(r'^test-url-with-arg/([-\w@]+)/$', lambda r, arg: HttpResponse('ok'), name='test_with_arg'),
+    url(r'^test-url-with-kwarg/(?P<arg>[-\w@]+)/$', lambda r, arg: HttpResponse('ok'), name='test_with_kwarg'),
 )


### PR DESCRIPTION
Hi there,

I recently faced a use case where the url parameters contained non traditional parameters like `%` `@` and so forth. This makes sure that the templatetag doesn't return false negative in such a case.

Please review ;)
