### PR TITLE
Add Django 1.11 support

### DIFF
--- a/activelink/__init__.py
+++ b/activelink/__init__.py
@@ -1,2 +1,2 @@
-__version__ = '0.4'
+__version__ = '1.0'
 __author__ = 'Jamie Matthews (http://j4mie.org) <jamie.matthews@gmail.com>'

--- a/activelink/templatetags/activelink.py
+++ b/activelink/templatetags/activelink.py
@@ -1,7 +1,12 @@
+from django import VERSION as DJANGO_VERSION
 from django.template import Library, Node, NodeList, VariableDoesNotExist
 from django.core.urlresolvers import NoReverseMatch
-from django.templatetags.future import url
 from django.template.defaulttags import TemplateIfParser
+
+if DJANGO_VERSION < (1, 5):
+    from django.templatetags.future import url
+else:
+    from django.template.defaulttags import url  # NOQA
 
 
 register = Library()

--- a/activelink/tests/__init__.py
+++ b/activelink/tests/__init__.py
@@ -1,17 +1,37 @@
+import django
+from django import VERSION as DJANGO_VERSION
 from django.conf import settings
 
 
 # bootstrap django
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [],
+        'APP_DIRS': True,
+    },
+]
+
+if DJANGO_VERSION[:2] >= (1, 9):
+    TEMPLATES[0].update(
+        {'OPTIONS': {'builtins': ['activelink.templatetags.activelink']}}
+    )
+
+
 settings.configure(
-    DATABASES = {
+    DATABASES={
         'default': {
             'ENGINE': 'django.db.backends.sqlite3',
             'NAME': ':memory:',
         }
     },
-    ROOT_URLCONF = 'activelink.tests.urls',
+    ROOT_URLCONF='activelink.tests.urls',
     INSTALLED_APPS=[
         'activelink',
         'activelink.tests',
-    ]
+    ],
+    TEMPLATES=TEMPLATES
 )
+
+if DJANGO_VERSION >= (1, 7):
+    django.setup()

--- a/activelink/tests/tests.py
+++ b/activelink/tests/tests.py
@@ -1,13 +1,14 @@
 import warnings
-from django.template import Template, Context, loader
+from django import VERSION as DJANGO_VERSION
+from django.template import Template, Context
 from django.test.client import RequestFactory
+
+if DJANGO_VERSION < (1, 9):
+    from django.template.base import add_to_builtins
+    add_to_builtins('activelink.templatetags.activelink')
 
 
 rf = RequestFactory()
-
-
-# add activelink to builtin tags
-loader.add_to_builtins('activelink.templatetags.activelink')
 
 
 def render(template_string, dictionary=None):

--- a/activelink/tests/urls.py
+++ b/activelink/tests/urls.py
@@ -1,5 +1,10 @@
-from django.conf.urls.defaults import *
+from django import VERSION as DJANGO_VERSION
 from django.http import HttpResponse
+
+if DJANGO_VERSION >= (1, 6):
+    from django.conf.urls import patterns, url
+else:
+    from django.conf.urls.defaults import patterns, url
 
 
 urlpatterns = patterns('',

--- a/activelink/tests/urls.py
+++ b/activelink/tests/urls.py
@@ -1,14 +1,20 @@
 from django import VERSION as DJANGO_VERSION
 from django.http import HttpResponse
 
-if DJANGO_VERSION >= (1, 6):
+
+if DJANGO_VERSION >= (1, 10):
+    from django.conf.urls import url
+elif DJANGO_VERSION >= (1, 6):
     from django.conf.urls import patterns, url
 else:
     from django.conf.urls.defaults import patterns, url
 
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^test-url/$', lambda r: HttpResponse('ok'), name='test'),
     url(r'^test-url-with-arg/([-\w]+)/$', lambda r, arg: HttpResponse('ok'), name='test_with_arg'),
     url(r'^test-url-with-kwarg/(?P<arg>[-\w]+)/$', lambda r, arg: HttpResponse('ok'), name='test_with_kwarg'),
-)
+]
+
+if DJANGO_VERSION < (1, 10):
+    urlpatterns = patterns('', *urlpatterns)


### PR DESCRIPTION
This builds on #6 and adds support up to Django 1.11. Tests now pass on all versions from 1.3-1.11.

Supersedes #5 and #6.